### PR TITLE
V13 compatibility update and refactoring

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3,7 +3,12 @@
     "settings": {
       "toggle-delete": {
         "name": "Always delete instead of disable",
-        "hint": "Instead of disabling some effects and deleting others, always delete a temporary effect toggled from the status menu."
+        "hint": "Instead of disabling some effects and deleting others, always delete a temporary effect toggled from the status menu.",
+        "options": {
+          "default": "Default (Delete if status-linked)",
+          "always-delete": "Always Delete",
+          "always-keep": "Always Keep (Disable)"
+        }
       }
     }
   }

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "temp-effects-as-statuses",
   "title": "Temporary Effects as Token Statuses",
   "description": "A module that makes it easy to disable or delete temporary effects.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "Andrew Krigline",
   "authors": [
     {
@@ -20,19 +20,10 @@
       "path": "lang/en.json"
     }
   ],
-  "scripts": [
-    "./scripts/temp-effects-as-statuses.js"
-  ],
-  "relationships": {
-    "requires": [{
-      "id": "lib-wrapper",
-      "compatibility": {
-        "minimum": "1.12.7.1"
-      }
-    }]
-  },
+  "scripts": ["./scripts/temp-effects-as-statuses.js"],
   "compatibility": {
-    "minimum": 10
+    "minimum": 13,
+    "verified": 13
   },
   "url": "https://github.com/ElfFriend-DnD/foundryvtt-temp-effects-as-statuses",
   "bugs": "https://github.com/ElfFriend-DnD/foundryvtt-temp-effects-as-statuses/issues",

--- a/scripts/temp-effects-as-statuses.js
+++ b/scripts/temp-effects-as-statuses.js
@@ -4,7 +4,13 @@ class TempEffectsAsStatuses {
 
   static SETTINGS = {
     toggleDelete: 'toggle-delete',
-  }
+  };
+
+  static TOGGLE_MODES = {
+    ALWAYS_DELETE: "always-delete",
+    ALWAYS_KEEP: "always-keep",
+    DEFAULT: "default",
+  };
 
   static log(...args) {
     if (game.modules.get('_dev-mode')?.api?.getPackageDebugValue(this.MODULE_NAME)) {
@@ -18,9 +24,14 @@ class TempEffectsAsStatuses {
       hint: `${this.MODULE_NAME}.settings.${this.SETTINGS.toggleDelete}.hint`,
       config: true,
       scope: 'world',
-      default: false,
-      type: Boolean,
-    })
+      default: this.TOGGLE_MODES.DEFAULT,
+      type: String,
+      choices: {
+        [this.TOGGLE_MODES.DEFAULT]: `${this.MODULE_NAME}.settings.${this.SETTINGS.toggleDelete}.options.${this.TOGGLE_MODES.DEFAULT}`,
+        [this.TOGGLE_MODES.ALWAYS_DELETE]: `${this.MODULE_NAME}.settings.${this.SETTINGS.toggleDelete}.options.${this.TOGGLE_MODES.ALWAYS_DELETE}`,
+        [this.TOGGLE_MODES.ALWAYS_KEEP]: `${this.MODULE_NAME}.settings.${this.SETTINGS.toggleDelete}.options.${this.TOGGLE_MODES.ALWAYS_KEEP}`,
+      },
+    });
   }
 }
 
@@ -28,68 +39,77 @@ Hooks.on('init', () => {
   console.log(`${TempEffectsAsStatuses.MODULE_NAME} | Initializing ${TempEffectsAsStatuses.MODULE_TITLE}`);
   TempEffectsAsStatusesTokenHUD.init();
   TempEffectsAsStatuses.registerSettings();
-})
+});
 
 Hooks.once('devModeReady', ({ registerPackageDebugFlag }) => {
   registerPackageDebugFlag(TempEffectsAsStatuses.MODULE_NAME);
 });
 
-Hooks.on('renderTokenHUD', (tokenHudApp, html, applicationData) => {
-  if (!tokenHudApp.object) {
-    return;
-  }
-
-  const statusEffects = html.find('.status-effects');
-
-  // filter out temporary effects from status icons
-  const filteredEffects = tokenHudApp.object.actor.temporaryEffects.filter((effect) => {
-    return !CONFIG.statusEffects.some(statusEffect => statusEffect.id === effect.getFlag('core', 'statusId'))
-  });
-
-  const newEffectIcons = `
-  ${filteredEffects.map(effect => `<img class="effect-control active" data-effect-uuid="${effect.uuid}" src="${effect.icon}" title="${effect.label}" data-status-id="${effect.uuid}" />`).join('')
-    }
-  `
-
-  TempEffectsAsStatuses.log(filteredEffects, newEffectIcons)
-
-  statusEffects.append(newEffectIcons);
-});
-
 class TempEffectsAsStatusesTokenHUD {
   static init() {
-    libWrapper.register(TempEffectsAsStatuses.MODULE_NAME, 'TokenHUD.prototype._onToggleEffect', TempEffectsAsStatusesTokenHUD.patchToggleEffect, "MIXED");
+    Hooks.on('renderTokenHUD', this.onRenderHUD.bind(this));
   }
 
-  static async patchToggleEffect(wrapped, event, config) {
-    event.preventDefault();
-    event.stopPropagation();
-    const img = event.currentTarget;
+  static onRenderHUD(app, element, data) {
+    const token = app?.object;
+    if (!token?.actor) return;
 
-    if (img.dataset.effectUuid) {
-      return TempEffectsAsStatusesTokenHUD.toggleEffectByUuid(img.dataset.effectUuid);
+    const statusEffectsEl = element.querySelector('.status-effects');
+    if (!statusEffectsEl) return;
+
+    // Filter out core status effects
+    const filteredEffects = token.actor.temporaryEffects.filter(effect => {
+      return !CONFIG.statusEffects.some(statusEffect =>
+        statusEffect.img === effect.img && effect.statuses?.has(statusEffect.id)
+      );
+    });
+
+    for (const effect of filteredEffects) {
+      const img = document.createElement('img');
+      img.classList.add('effect-control', 'active');
+      img.dataset.effectUuid = effect.uuid;
+      img.src = effect.icon;
+      img.title = effect.name;
+      img.dataset.statusId = effect.uuid;
+      img.addEventListener('click', this.onClickEffect.bind(this));
+      statusEffectsEl.appendChild(img);
     }
 
-    return wrapped(event, config);
+    TempEffectsAsStatuses.log('Added temporary effects:', filteredEffects);
+  }
+
+  static async onClickEffect(event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const img = event.currentTarget;
+    const uuid = img.dataset.effectUuid;
+    if (!uuid) return;
+
+    return await this.toggleEffectByUuid(uuid);
+  }
+
+  static checkDeleteEffect(effect) {
+    const toggleMode = game.settings.get(
+      TempEffectsAsStatuses.MODULE_NAME,
+      TempEffectsAsStatuses.SETTINGS.toggleDelete
+    );
+    return TempEffectsAsStatuses.TOGGLE_MODES.ALWAYS_KEEP !== toggleMode && (
+      +effect.statuses?.size > 0
+      || TempEffectsAsStatuses.TOGGLE_MODES.ALWAYS_DELETE === toggleMode
+    );
   }
 
   static async toggleEffectByUuid(effectUuid) {
     const effect = fromUuidSync(effectUuid);
-    const alwaysDelete = game.settings.get(TempEffectsAsStatuses.MODULE_NAME, TempEffectsAsStatuses.SETTINGS.toggleDelete);
+    if (!effect) return false;
 
-    // nuke it if it has a statusId
-    // brittle assumption
-    // provides an option to always do this
-    if (effect.getFlag('core', 'statusId') || alwaysDelete) {
-      const deleted = await effect.delete();
-      return !!deleted;
+    if (TempEffectsAsStatusesTokenHUD.checkDeleteEffect(effect)) {
+      await effect.delete();
+    } else {
+      await effect.update({ disabled: !effect.disabled });
     }
 
-    // otherwise toggle its disabled status
-    const updated = await effect.update({
-      disabled: !effect.disabled,
-    });
-
-    return !!updated;
+    return true;
   }
 }

--- a/scripts/temp-effects-as-statuses.js
+++ b/scripts/temp-effects-as-statuses.js
@@ -68,7 +68,7 @@ class TempEffectsAsStatusesTokenHUD {
       const img = document.createElement('img');
       img.classList.add('effect-control', 'active');
       img.dataset.effectUuid = effect.uuid;
-      img.src = effect.icon;
+      img.src = effect.icon || effect.img;
       img.title = effect.name;
       // img.dataset.statusId = effect.uuid;
       img.addEventListener('click', this.onClickEffect.bind(this));

--- a/scripts/temp-effects-as-statuses.js
+++ b/scripts/temp-effects-as-statuses.js
@@ -70,7 +70,7 @@ class TempEffectsAsStatusesTokenHUD {
       img.dataset.effectUuid = effect.uuid;
       img.src = effect.icon;
       img.title = effect.name;
-      img.dataset.statusId = effect.uuid;
+      // img.dataset.statusId = effect.uuid;
       img.addEventListener('click', this.onClickEffect.bind(this));
       statusEffectsEl.appendChild(img);
     }


### PR DESCRIPTION
> I have no idea if there is any way to achieve the same functionallity in FVTTv13 but this module looks cool so I CAST REVIVIFY

Here are main updates proposed by this PR:

- V13 support
- No dependencies
- Added: A nice toggle to **EVER NEVER** delete an effect (_I have no idea why it's expected for an effect "to be short-lived or re-created frequently" at the first place but I deeply disagre with this statement_)

Testing:
Clicked a few times — so far it's working. If I find any issues, I’ll open a new PR. _No refunds_